### PR TITLE
Add Modal containing the screenshot and fix the crop of screenshot 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "prop-types": "15.7.2",
     "react": "16.8.6",
     "react-dom": "16.8.6",
+    "react-modal": "^3.11.2",
     "react-redux": "7.2.2",
-    "react-scripts": "3.0.1",
+    "react-scripts": "^4.0.0",
     "redux": "4.0.5"
   },
   "scripts": {

--- a/src/components/HoursPlanning.js
+++ b/src/components/HoursPlanning.js
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import AwIcon from 'awicons-react';
 import { connect } from 'react-redux';
 import { forEach, find } from 'lodash'
-import html2canvas from 'html2canvas';
 
 import "../style/HoursPlanning.scss";
 
 import TeamMate from "./TeamMate";
 import { addMateAction, setEmergencyAction } from "../store/actions";
-import { calcTotal } from "../utilities";
+import {calcTotal, generateScreenshot} from "../utilities";
+import ScreenshotModal from "./ScreenshotModal";
 
 class HoursPlanning extends React.Component {
 
@@ -25,6 +25,8 @@ class HoursPlanning extends React.Component {
 
   state = {
     editMode: false,
+    image: null,
+    isModalOpen: false
   };
 
   _onChangeEmergency = (ev) => {
@@ -44,19 +46,12 @@ class HoursPlanning extends React.Component {
     }
   };
 
-  _screen = (selector) => {
-    const height = window.scrollY;
-    window.scrollTo(0, 0);
-    html2canvas(document.querySelector(`#${selector}`))
-      .then(canvas => {
-        const img = canvas.toDataURL();
-        const link = document.createElement("a");
-        const date = new Date(this.props.date);
-        link.download = `sprintPlanning_${selector}_${date.getFullYear()}-${date.getMonth()+1}-${date.getDate()}`;
-        link.href = img;
-        link.click();
-      });
-    window.scrollTo(0, height);
+  _showScreenshot = (selector) => {
+    generateScreenshot(selector, false)
+    .then(screenshot => {
+      this.setState({image: screenshot});
+      this.setState({isModalOpen: true});
+    });
   };
 
   _onPlusClick = () => {
@@ -95,9 +90,14 @@ class HoursPlanning extends React.Component {
           <h3>{name}</h3>
           <div style={{ display: 'flex' }}>
             <AwIcon
+              iconName="download"
+              className="icon"
+              onClick={() => generateScreenshot(name.toLowerCase().replace("-", ""), true)}
+            />
+            <AwIcon
               iconName="camera"
               className="icon"
-              onClick={() => this._screen(name.toLowerCase().replace("-", ""))}
+              onClick={() => this._showScreenshot(name.toLowerCase().replace("-", ""))}
             />
             <AwIcon
               iconName="pencil-alt"
@@ -146,6 +146,11 @@ class HoursPlanning extends React.Component {
         <div className="total">
           <p>Totale: {parseInt(total)} h</p>
         </div>
+        <ScreenshotModal
+          isModalOpen={this.state.isModalOpen}
+          closeModal={() => this.setState({isModalOpen: false})}
+          screenshot={this.state.image}
+        />
       </div>
     )
   }

--- a/src/components/ScreenshotModal.js
+++ b/src/components/ScreenshotModal.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import Modal from "react-modal";
+import AwIcon from "awicons-react";
+
+import "../style/ScreenshotModal.scss"
+
+/**
+ * Creates a Modal containing the screenshot to show.
+ *
+ * @param isModalOpen is a boolean indicating if the modal should be shown or not
+ * @param closeModal is a function of the action to be done when the user want to close the modal
+ * @param screenshot is the blob of the image to show
+ * @returns {JSX.Element}
+ *
+ * @author Federico Rispo
+ */
+export default function ScreenshotModal({isModalOpen, closeModal, screenshot}) {
+  return (
+    <Modal
+      className={'screenshotModal'}
+      overlayClassName={'overlayScreenshotModal'}
+      isOpen={isModalOpen}
+      onClose={closeModal}
+      onRequestClose={closeModal}
+    >
+      <AwIcon
+        iconName="times"
+        className={"closeScreenshotModal"}
+        onClick={closeModal}
+      />
+      <img src={screenshot} alt="generated screenshot"/>
+    </Modal>
+  );
+}

--- a/src/style/ScreenshotModal.scss
+++ b/src/style/ScreenshotModal.scss
@@ -1,0 +1,43 @@
+@import "variables";
+
+.screenshotModal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 0 12%;
+
+  border: 1px solid #ccc;
+  overflow: no-display;
+  border-radius: 4px;
+  outline: none;
+  background-color: white;
+
+  .closeScreenshotModal {
+    position: absolute;
+    right: 0;
+    margin-right: 1%;
+    font-size: 40px;
+    color: $blue3;
+    cursor: pointer;
+    :hover {
+      color: $orange1;
+    }
+  }
+
+  img {
+    height: 100%;
+    width: 100%;
+    margin: 3% 0;
+    object-fit: contain;
+  }
+}
+
+.overlayScreenshotModal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+}

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,4 +1,5 @@
-import { forEach } from "lodash";
+import {forEach} from "lodash";
+import html2canvas from "html2canvas";
 
 export function calcTotal(allMates, mates, emergency) {
   let total = 0;
@@ -36,4 +37,47 @@ export function decodeJSON(fileJSON) {
   }
 
   return { info, groups, mates };
+}
+
+/**
+ * Generates the relative screenshot of a specific dom element. If isDownloadable is false than the function does not
+ * generate the link to download but returns the screenshot, otherwise a link pointing to the image to download is
+ * created. The scroll is positioned to zero before capturing the screenshot and then it is restored.
+ *
+ * @param selector represents the element to capture
+ * @param isDownloadable is false if the image should be shown in the modal, true if the image should be downloaded.
+ * @return a Promise that returns the screenshot captured or it creates the link to download the image.
+ * @author Federico Rispo
+ */
+export function generateScreenshot(selector, isDownloadable) {
+  /*
+   * Get the dimensions of the element to screenshot and add 5 pixel to them because the html2canvas library probably
+   * adds a little margin to the left and this causes a few pixels to be cut to the right.
+   */
+  const widthScreenshot = document.getElementById(selector).clientWidth + 10;
+  const heightScreenshot = document.getElementById(selector).clientHeight + 5;
+
+  const height = window.scrollY;
+  window.scrollTo(0, 0);
+  let promiseCanvas = html2canvas(document.querySelector(
+    `#${selector}`),
+    {width: widthScreenshot, height: heightScreenshot}
+  );
+  window.scrollTo(0, height);
+
+  return promiseCanvas
+  .then(canvas => {
+    const screenshot = canvas.toDataURL();
+
+    if (!isDownloadable) {
+      return screenshot;
+    }
+
+    // Generate the link
+    const link = document.createElement("a");
+    const date = new Date();
+    link.download = `sprintPlanning_${selector}_${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
+    link.href = screenshot;
+    link.click();
+  });
 }


### PR DESCRIPTION
- Created an utility function to generate the screenshot and the related
  link to download it. This follows the DRY principle.
- Created the `ScreenshotModal` component to allow the user to preview and
  copy the screenshot without downloading it.
- Added icons to open the modal.
- Fixed a strange behaviour of `html2canvas` that cropps some right pixels
  of the specified element.